### PR TITLE
Add recursive option to submodule initialization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## Running
 
-Add katsu submodule to the current directory
+Add katsu submodule (and its own dependency submodules) to the current directory
 ```
 git pull
-git submodule update --init
+git submodule update --init --recursive
 ```
 
 Generate internal TLS certificates, self-signed by a root CA:


### PR DESCRIPTION
Small tweak to the README setup instructions. Fixes the following type of error during Katsu startup, by initializing the submodule for the DATS JSON schemas:
```
FileNotFoundError: [Errno 2] No such file or directory: '/app/chord_metadata_service/chord_metadata_service/dats/person_schema.json'
```