### PR TITLE
Get rid of references to beacon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       IDP_CLIENT_ID: mock_permissions_client
       IDP_CLIENT_SECRET: mockpermissions_secret
       CLIENT_SECRET_ROOT: my-secret-root-token
-      CLIENT_SECRET_BEACON: my-secret-beacon-token
+      CLIENT_SECRET_SERVICE: my-secret-service-token
     command:
       - "run"
       - "--server"
@@ -99,6 +99,6 @@ services:
       CANDIG_OPA_URL: https://opa:8181
       CANDIG_OPA_VERSION: rego_dev_playground
       ROOT_CA: /rootCA.crt
-      PERMISSIONS_SECRET: my-secret-beacon-token
+      PERMISSIONS_SECRET: my-secret-service-token
 volumes:
   katsu-db-data:

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -19,13 +19,13 @@ rights = {
 
 env := opa.runtime().env
 root_token := object.get(env, "CLIENT_SECRET_ROOT", "no_root_token")
-beacon_token := object.get(env, "CLIENT_SECRET_BEACON", "no_beacon_token")
+service_token := object.get(env, "CLIENT_SECRET_SERVICE", "no_service_token")
 
 tokens = {
     root_token : {
         "roles": ["admin"]
     },
-    beacon_token : {
+    service_token : {
         "roles": ["datasets", "tokenControlledAccessREMS"]
     }
 }

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -28,9 +28,9 @@ input_paths = ["/api/phenopackets/?.*", "/api/datasets/?.*", "/api/diagnoses/?.*
 #
 # Provided: 
 # input = {
-#     'token': user token (passed to /introspect and /userinfo)
-#     'method': method requested on beacon
-#     'path': path to request on beacon
+#     'token': user token 
+#     'method': method requested at data service
+#     'path': path to request at data service
 # }
 #
 
@@ -46,7 +46,7 @@ import data.idp.username
 default registered_allowed = []
 
 registered_allowed = registered_datasets {
-    valid_token                  # extant, valid token
+    valid_token         # extant, valid token
     trusted_researcher  # has claim we're using for registered access
 }
 
@@ -58,19 +58,6 @@ default controlled_allowed = []
 
 controlled_allowed = controlled_access_list[username]{
     valid_token                  # extant, valid token
-}
-
-#List of all allowed datasets for this request
-
-datasets = array.concat(array.concat(open_datasets, registered_allowed), controlled_allowed) {
-    input.method = "GET"                   # only allow GET requestst
-    input.path = ["beacon"]
-}
-
-datasets = array.concat(open_datasets, opt_in_datasets) {
-     valid_token == true
-     input.method = "GET"
-     input.path = ["counts"]
 }
 
 #


### PR DESCRIPTION
This used to involve a fake beacon, now there's real data services - get rid of some confusing references to beacon.  They're still there in some harmless places (like nonexistent redirect URIs)