### PR TITLE
Simplify OPA deployment by removing unnecessary files and env variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       - ./permissions_engine/tls.crt:/public.crt
       - ./permissions_engine/tls.key:/private.key
       - ./permissions_engine/data.json:/data.json
-      - ./rootCA.crt:/rootCA.crt
     environment:
       CLIENT_SECRET_ROOT: my-secret-root-token
       CLIENT_SECRET_SERVICE: my-secret-service-token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,6 @@ services:
       - ./permissions_engine/data.json:/data.json
       - ./rootCA.crt:/rootCA.crt
     environment:
-      IDP: https://oidc1:8443/auth/realms/mockrealm/ https://oidc2:8443/auth/realms/mockrealm/
-      ROOT_CA: /rootCA.crt
-      IDP_CLIENT_ID: mock_permissions_client
-      IDP_CLIENT_SECRET: mockpermissions_secret
       CLIENT_SECRET_ROOT: my-secret-root-token
       CLIENT_SECRET_SERVICE: my-secret-service-token
     command:


### PR DESCRIPTION
Earlier versions of [predecessors](https://github.com/ljdursi/beacon_permission_service) of this repo had OPA directly communicating with the IDP to verify the token hadn't been revoked, etc.  That means it needed to know the IDPs, needed to have clients for the IDPs, and needed the root certificate to validate TLS connection to the IDPs.

That wasn't a great idea and has long been gone from this repo (if it was ever here?) but environment variables and a volume mount still lingered.  Get rid of that.